### PR TITLE
Add type = api in  ZohoClient .This will return only the modules that…

### DIFF
--- a/src/ZohoClient.php
+++ b/src/ZohoClient.php
@@ -398,7 +398,7 @@ class ZohoClient
      */
     public function getModules()
     {
-        return $this->call('Info', 'getModules', []);
+        return $this->call('Info', 'getModules', ['type' => 'api']);
     }
 
     /**


### PR DESCRIPTION
… are accessible via API.
