### PR TITLE
[BUGFIX] Corrupted modules names in non english

### DIFF
--- a/src/Service/EntitiesGeneratorService.php
+++ b/src/Service/EntitiesGeneratorService.php
@@ -58,8 +58,8 @@ class EntitiesGeneratorService
             if($module->isApiSupported()) {
                 try {
                     $module = $this->generateModule(
-                        $module->getAPIName(), $module->getPluralLabel(),
-                        $module->getSingularLabel(), $targetDirectory, $namespace
+                        $module->getAPIName(), $module->getAPIName(),
+                        substr($module->getAPIName(), 0, -1), $targetDirectory, $namespace
                     );
                     if($module) {
                         $zohoModules[] = $module;


### PR DESCRIPTION
getPluralLabel and getSingularLabel return translated modules names that can contains accented characters that won't be used in classname generation.

Other problem, tests will fail because class name have changed.

This patch simply generate singular / plural by getting the ApiName which is in english and remove the last char (s) for singular value.