### PR TITLE
[FEATURE] Add abilioty to inject unsupported field

### DIFF
--- a/src/AbstractZohoDao.php
+++ b/src/AbstractZohoDao.php
@@ -22,6 +22,15 @@ abstract class AbstractZohoDao
      */
     protected $zohoClient;
 
+
+    /**
+     * Array that contains fields that can't be managed
+     * with the ORM and are manually added with the
+     * addUnmanagedField method
+     * @var array
+     */
+    protected $unmanagedFields =  [];
+
     public function __construct(ZohoClient $zohoClient)
     {
         $this->zohoClient = $zohoClient;
@@ -323,5 +332,23 @@ abstract class AbstractZohoDao
         );
 
         return count($field) === 1?$field[0] :null;
+    }
+
+
+    /**
+     * Add a field that can't be managed with the ORM
+     *
+     * @param $fieldApiName
+     * @param $value
+     */
+    public function addUnmanagedField($fieldApiName, $value) {
+        $this->unmanagedFields[$fieldApiName] = $value;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUnamanagedFields() {
+        return $this->unmanagedFields;
     }
 }

--- a/src/Helpers/BeanHelper.php
+++ b/src/Helpers/BeanHelper.php
@@ -70,6 +70,11 @@ class BeanHelper
                 break;
             }
         }
+
+        // Add support for fields that can't be managed with ORM
+        foreach ($dao->getUnamanagedFields() as $field => $value) {
+            $bean->getZCRMRecord()->setFieldValue($field, $value);
+        }
     }
 
     /**


### PR DESCRIPTION
This is a quick fix to allow to inject custom fields in API requests that don't have getters/setters generated in the ORM.

This could be used to manage for example the following fields:
- $se_module, required for links creation
- $line_fields, may be used in invoices
